### PR TITLE
Save logs on separate Redis list based on their levels

### DIFF
--- a/lib/winston-redis.js
+++ b/lib/winston-redis.js
@@ -81,18 +81,21 @@ Redis.prototype.log = function (level, msg, meta, callback) {
       container = this.container(meta),
       channel = this.channel && this.channel(meta);
 
+  // Separate logs based on their levels
+  container += ":" + level;
   this.redis.llen(container, function (err, len) {
     if (err) {
       if (callback) callback(err, false);
       return self.emit('error', err);
     }
-
+    // Assigns an unique ID to each log
+    meta.id = len + 1
     var output = common.log({
       level: level,
       message: msg,
       meta: meta,
       timestamp: self.timestamp,
-      json: self.json
+      json: self.json,
     });
 
     // RPUSH may be better for poll-streaming.
@@ -137,8 +140,10 @@ Redis.prototype.query = function (options, callback) {
   var options = this.normalizeQuery(options),
       start = options.start || 0,
       end = options.rows + start,
-      container = this.container(options);
+      container = this.container(options)
+      level = options.level;
 
+  container += ":" + level;
   this.redis.lrange(container, start, end - 1, function (err, results) {
     if (err) return callback(err);
 


### PR DESCRIPTION
Instead of saving all logs in a single list they could be saved on separate lists and use the log's level to generate the key name.
