### PR TITLE
UPDATE: Save different logs into separate redis lists

### DIFF
--- a/lib/winston-redis.js
+++ b/lib/winston-redis.js
@@ -78,7 +78,7 @@ winston.transports.Redis = Redis;
 //
 Redis.prototype.log = function (level, msg, meta, callback) {
   var self = this,
-      container = this.container(meta),
+      container = this.container(level, msg, meta),
       channel = this.channel && this.channel(meta);
 
   this.redis.llen(container, function (err, len) {
@@ -137,7 +137,10 @@ Redis.prototype.query = function (options, callback) {
   var options = this.normalizeQuery(options),
       start = options.start || 0,
       end = options.rows + start,
-      container = this.container(options);
+      meta = options.meta || ""
+      level = options.level || ""
+      msg = options.msg || ""
+      container = this.container(level, msg, meta);
 
   this.redis.lrange(container, start, end - 1, function (err, results) {
     if (err) return callback(err);


### PR DESCRIPTION
Addressed suggestions from https://github.com/indexzero/winston-redis/pull/6

Let me know if this is what you had in mind.
I wasn't too sure about what to pass to the container function in the query method.
I'm assuming that the level, msg and meta could be sent in as part of the options obj which if that's the case would work just fine.
