### PR TITLE
Allow for closing connection

### DIFF
--- a/lib/winston-redis.js
+++ b/lib/winston-redis.js
@@ -280,3 +280,10 @@ Redis.prototype.stream = function (options) {
 
   return stream;
 };
+
+//Close Connection to redis Server 
+//Winston will call close function from clear/remove to attempt to cleanly exit.
+Redis.prototype.close = function(){
+  if (this.redis)
+    this.redis.end();
+};


### PR DESCRIPTION
This allows winston.clear and winston.remove to end the stream and not hang.