### PR TITLE
-) added support for label (logger categories).

### DIFF
--- a/lib/winston-redis.js
+++ b/lib/winston-redis.js
@@ -29,6 +29,7 @@ var Redis = exports.Redis = function (options) {
   this.channel   = options.pchannel || options.channel;
   this.pattern   = options.pattern || !!options.pchannel;
   this.logstash  = options.logstash === true;
+  this.label     = options.label || null;
 
   if (options.auth) {
     this.redis.auth(options.auth);
@@ -95,7 +96,8 @@ Redis.prototype.log = function (level, msg, meta, callback) {
       meta: meta,
       timestamp: self.timestamp,
       json: self.json,
-      logstash : self.logstash
+      logstash: self.logstash,
+      label: self.label
     });
 
     self.redis.lpush(container, output, function (err) {
@@ -279,4 +281,11 @@ Redis.prototype.stream = function (options) {
   });
 
   return stream;
+};
+
+// Close connection to redis server
+// Winston will call close function from clear/remove to attempt to cleanly exit.
+Redis.prototype.close = function() {
+  if (this.redis)
+    this.redis.end();
 };


### PR DESCRIPTION
-) added support for label (logger categories): will work together with the following winston pull request: https://github.com/flatiron/winston/pull/326

-) added close() function to allow winston to end the connection to the redis server (taken from https://github.com/Unroll-Me/winston-redis/commit/098fb98fdb39cb7f4ece2d0450475722391aa09e )