### PR TITLE
Add Expiry Property to allow log containers to expire

### DIFF
--- a/lib/winston-redis.js
+++ b/lib/winston-redis.js
@@ -30,6 +30,7 @@ var Redis = exports.Redis = function (options) {
   this.channel   = options.pchannel || options.channel;
   this.pattern   = options.pattern || !!options.pchannel;
   this.logstash  = options.logstash === true;
+  this.expire    = options.expire || 0;
 
   if (options.auth) {
     this.redis.auth(options.auth);
@@ -104,6 +105,13 @@ Redis.prototype.log = function (level, msg, meta, callback) {
   async.series([
     function(cb) {
       self.redis.lpush(container, output, cb);
+    },
+    function(cb) {
+      if(self.expire) {
+        self.redis.expire(container, self.expire, cb);
+      } else {
+        cb();
+      }
     },
     function(cb) {
       self.redis.ltrim(container, 0, self.length, cb);
@@ -283,7 +291,7 @@ Redis.prototype.stream = function (options) {
   return stream;
 };
 
-//Close Connection to redis Server 
+//Close Connection to redis Server
 //Winston will call close function from clear/remove to attempt to cleanly exit.
 Redis.prototype.close = function(){
   if (this.redis)


### PR DESCRIPTION
```Javascript
var redisTransport  = new Redis({
    length: 5000,
    container: 'logsContainer',
    level: 'info',
    expire: 7 * 24 * 60 * 60 // Expire in a week's time.
})
```