### PR TITLE
Add Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+sudo: false
+services:
+  - redis-server
+language: node_js
+node_js:
+  - "0.12"


### PR DESCRIPTION
Unit tests are currently failing with node@0.12

```
TypeError: undefined is not a function
    at Redis.stream (/home/travis/build/moretti/winston-redis/lib/winston-redis.js:197:22)
    at /home/travis/build/moretti/winston-redis/node_modules/winston/lib/winston/logger.js:342:28
    at Array.forEach (native)
    at Logger.stream (/home/travis/build/moretti/winston-redis/node_modules/winston/lib/winston/logger.js:341:14)
   at Object.out.the stream() method.using no options.topic (/home/travis/build/moretti/winston-redis/node_modules/winston/test/transports/transport.js:61:31)
    at run (/home/travis/build/moretti/winston-redis/node_modules/vows/lib/vows/suite.js:133:35)
    at EventEmitter.<anonymous> (/home/travis/build/moretti/winston-redis/node_modules/vows/lib/vows/suite.js:235:40)
    at EventEmitter.emit (events.js:129:20)
    at EventEmitter.options.Emitter.emit (/home/travis/build/moretti/winston-redis/node_modules/vows/lib/vows.js:241:24)
    at /home/travis/build/moretti/winston-redis/node_modules/vows/lib/vows/suite.js:170:45', message: 'undefined is not a function
```

https://travis-ci.org/moretti/winston-redis/builds/81559995