### PR TITLE
add meta option to add custom fields to each log

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ In addition to these, the Redis transport also accepts the following options.
 
 * __length:__ (Default **200**) Number of log messages to store.
 * __container:__ (Default **winston**) Name of the Redis container you wish your logs to be in.
-* __channel:__ (Default **None**) Name of the Redis channel to stream logs from. 
+* __channel:__ (Default **None**) Name of the Redis channel to stream logs from.
+* __meta:__ (Default **{}**) Custom fields to add to each log.
 
 *Metadata:* Logged as JSON literal in Redis
 

--- a/lib/winston-redis.js
+++ b/lib/winston-redis.js
@@ -10,7 +10,8 @@ var redis = require('redis'),
     common = require('winston/lib/winston/common'),
     util = require('util'),
     Stream = require('stream').Stream,
-    async = require('async');
+    async = require('async'),
+    _ = require('lodash');
 
 var Redis = exports.Redis = function (options) {
   winston.Transport.call(this, options);
@@ -30,6 +31,7 @@ var Redis = exports.Redis = function (options) {
   this.channel   = options.pchannel || options.channel;
   this.pattern   = options.pattern || !!options.pchannel;
   this.logstash  = options.logstash === true;
+  this.metadata  = options.meta || {};
 
   if (options.auth) {
     this.redis.auth(options.auth);
@@ -87,7 +89,7 @@ Redis.prototype.log = function (level, msg, meta, callback) {
   var output = common.log({
     level:       level,
     message:     msg,
-    meta:        meta,
+    meta:        _.merge(meta, this.metadata),
     json:        this.json,
     logstash:    this.logstash,
     colorize:    this.colorize,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "dependencies": {
     "async": "^1.2.1",
+    "lodash": "3.10.x",
     "redis": "0.12.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Add a new option "meta" allowing to set custom metadata to add to all logs.