### PR TITLE
Downgrade redis version to 0.12.2 so it is compatible with kue's requirements

### DIFF
--- a/lib/winston-redis.js
+++ b/lib/winston-redis.js
@@ -21,8 +21,9 @@ var Redis = exports.Redis = function (options) {
   options       = options || {};
 
   this.name      = 'redis';
-
-  if (options.redis instanceof redis.RedisClient) {
+    
+  if (options.redis instanceof redis.RedisClient ||
+      (options.redis.lpush && options.redis.ltrim || options.redis.lrange)) {
     this.redis = options.redis;
   } else if (options.redis instanceof Object) {
     this.redis = redis.createClient(options.redis);

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "async": "^1.2.1",
     "lodash": "^4.6.1",
-    "redis": "^0.12.3",
+    "redis": "^0.12.2",
     "pkginfo": "0.3.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-redis",
   "description": "A fixed-length Redis transport for winston",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "dependencies": {
     "async": "^1.2.1",
     "lodash": "^4.6.1",
-    "redis": "git+ssh://git@github.com/spotme/node_redis",
+    "redis": "^0.12.3",
     "pkginfo": "0.3.x"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "async": "^1.2.1",
     "lodash": "^4.6.1",
-    "redis": "spotme/node_redis"
+    "redis": "git+ssh://git@github.com/spotme/node_redis"
   },
   "devDependencies": {
     "vows": "0.8.x"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "dependencies": {
     "async": "^1.2.1",
     "lodash": "^4.6.1",
-    "redis": "git+ssh://git@github.com/spotme/node_redis"
+    "redis": "git+ssh://git@github.com/spotme/node_redis",
+    "pkginfo": "0.3.x"
   },
   "devDependencies": {
     "vows": "0.8.x"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "async": "^1.2.1",
     "lodash": "^4.6.1",
-    "redis": "~0.12.3"
+    "redis": "spotme/node_redis"
   },
   "devDependencies": {
     "vows": "0.8.x"

--- a/package.json
+++ b/package.json
@@ -16,14 +16,14 @@
   ],
   "dependencies": {
     "async": "^1.2.1",
-    "lodash": "^4.6.1"
+    "lodash": "^4.6.1",
+    "redis": "git@github.com:Spotme/node_redis.git"
   },
   "devDependencies": {
     "vows": "0.8.x"
   },
   "peerDependencies": {
-    "redis": "^2.0.0",
-    "winston": "^2.0.0"
+    "winston": "^1.0.1"
   },
   "main": "./lib/winston-redis",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-redis",
   "description": "A fixed-length Redis transport for winston",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",
@@ -17,7 +17,7 @@
   "dependencies": {
     "async": "^1.2.1",
     "lodash": "^4.6.1",
-    "redis": "git@github.com:Spotme/node_redis.git"
+    "redis": "~0.12.3"
   },
   "devDependencies": {
     "vows": "0.8.x"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "winston-redis",
   "description": "A fixed-length Redis transport for winston",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Charlie Robbins <charlie.robbins@gmail.com>",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This allows backend to install without npm.4pax.com