### PR TITLE
fix: treating any possible error on redis calls

### DIFF
--- a/lib/winston-redis.js
+++ b/lib/winston-redis.js
@@ -47,15 +47,16 @@ class Redis extends Transport {
     this.metadata  = options.meta || {};
     this.flatMeta  = options.flatMeta || false;
 
-    if (options.auth) {
-      this.redis.auth(options.auth);
-    }
+    this.errorCallback = (err) => {
+      this.emit('error', err);
+    };
 
+    if (options.auth) {
+      this.redis.auth(options.auth).catch(this.errorCallback);
+    }
     if (this.createdClient) {
       // Suppress errors from the Redis client
-      this.redis.on('error', (err) => {
-        this.emit('error', err);
-      });
+      this.redis.on('error', this.errorCallback);
     }
 
     if (typeof this.container !== 'function') {
@@ -93,8 +94,8 @@ class Redis extends Transport {
       : JSON.stringify({ level, message, meta });
 
     async.series([
-      (cb) => this.redis.lpush(container, output, cb),
-      (cb) => this.redis.ltrim(container, 0, this.length, cb)
+      (cb) => this.redis.lpush(container, output, cb).catch(this.errorCallback),
+      (cb) => this.redis.ltrim(container, 0, this.length, cb).catch(this.errorCallback)
     ], (err) => {
       if (err) {
         if (callback) callback(err, false);
@@ -102,7 +103,7 @@ class Redis extends Transport {
       }
 
       if (channel) {
-        this.redis.publish(channel, output);
+        this.redis.publish(channel, output).catch(errorCallback);
       }
 
       this.emit('logged', info);


### PR DESCRIPTION
Although the library listens to redis error event, some errors like connection Timeout, surprisingly, are not emitting such event, and as the redis calls are creating floating promises, since node 16, an unhandled exception ends up shutting down the application.

With this PR, we try to catch every possible error in every Redis call to avoid that, as connection Timeout may occur from any command.